### PR TITLE
Worked MailerLite script into header finally

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
-import Container from '@/app/ui/container'
+import Container from '@/app/ui/container';
+import Subscribeform from '@/app/ui/subscribeform';
 
 export default function Page() {
   return (
@@ -47,6 +48,7 @@ export default function Page() {
       <p>
         We'll grow and offer more as you dream with us, too.
       </p>
+      <Subscribeform />
     </Container>
     );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,8 +1,8 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
-import Header from '@/app/ui/header'
-import Footer from '@/app/ui/footer'
-
+import Header from '@/app/ui/header';
+import Footer from '@/app/ui/footer';
 
 export const metadata: Metadata = {
   title: "Meadow Reveries",
@@ -11,11 +11,24 @@ export const metadata: Metadata = {
 
 export default function RootLayout({
   children,
-}: Readonly<{
+}: {
   children: React.ReactNode;
-}>) {
+}) {
   return (
     <html lang="en">
+      <head>
+        <Script
+          id="mailerLite"
+          strategy="afterInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `(function(w,d,e,u,f,l,n){w[f]=w[f]||function(){(w[f].q=w[f].q||[])
+                    .push(arguments);},l=d.createElement(e),l.async=1,l.src=u,
+                    n=d.getElementsByTagName(e)[0],n.parentNode.insertBefore(l,n);})
+                    (window,document,'script','https://assets.mailerlite.com/js/universal.js','ml');
+                    ml('account', '1003795');`,
+          }}
+        />
+      </head>
       <body>
       <Header />
         {children}

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,7 +1,7 @@
-import Container from '@/app/ui/container'
-import Card from '@/app/ui/card'
-import Link from 'next/link'
-import Subscribe from '@/app/ui//subscribe'
+import Container from '@/app/ui/container';
+import Card from '@/app/ui/card';
+import Link from 'next/link';
+import Subscribeform from '@/app/ui//subscribeform';
 
 export default function Page() {
   return (
@@ -38,7 +38,7 @@ export default function Page() {
             </p>
           </Card>
         </div>
-          <Subscribe />
+          <Subscribeform />
       </main>
     </Container>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,23 +1,10 @@
-import Card from '@/app/ui/card'
-import Link from 'next/link'
+import Subscribeform from '@/app/ui/subscribeform';
 
 export default function Home() {
   return (
     <div className="bg-[url('bg-main.png')] sm:bg-left-bottom md:bg-center lg:bg-top bg-cover bg-no-repeat min-h-screen p-6">
       <main>
-        <Card
-          cardBackground = "paper"
-          headerBackground = "milkweed"
-          headerText = "Be an early bird"
-          img = "/card_CTA_subscribe.png"
-          alt = "A needle-felted, round female Northern Cardinal sits on some rocks in front of a wild flower garden."
-        >
-            <h3 className="my-2 text-center"><strong>We're still growing!</strong></h3>
-            <div className="m-6 text-center">
-              <Link href="https://subscribepage.io/meadowreveries" target="_blank" className="text-xl bg-milkweed text-black border border-seed hover:text-black hover:border-aster hover:bg-ladycardinal p-4 rounded">Subscribe</Link>
-            </div>
-            <p><a href="https://subscribepage.io/meadowreveries" className="text-aster" target="_blank">Subscribe to our mailing list</a>. We'll email you once our borb crafting kits and handmade pieces, <strong>daydreams made in felt</strong>, take flight.</p>
-        </Card>
+            <Subscribeform />
       </main>
     </div>
   );

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -1,7 +1,7 @@
-import Container from '@/app/ui/container'
-import Card from '@/app/ui/card'
-import Link from 'next/link'
-import Subscribe from '@/app/ui//subscribe'
+import Container from '@/app/ui/container';
+import Card from '@/app/ui/card';
+import Link from 'next/link';
+import Subscribeform from '@/app/ui//subscribeform';
 
 export default function Page() {
   return (
@@ -71,7 +71,7 @@ export default function Page() {
             </p>
           </Card>
         </div>
-          <Subscribe />
+          <Subscribeform />
       </main>
     </Container>
   );

--- a/app/ui/header.tsx
+++ b/app/ui/header.tsx
@@ -26,7 +26,7 @@ export default function Header() {
 	        		height="36"
 	        		width="46"
 	        	/>
-	        	<Link className="font-semibold text-xl tracking-wide uppercase text-black" href="/">Meadow Reveries</Link>
+	        	<a className="font-semibold text-xl tracking-wide uppercase text-black" href="/">Meadow Reveries</a>
 	      	</div>
 	      	<div className="lg:hidden block">
 	        	<button className="flex items-center px-3 py-2 border rounded text-black border-black hover:text-fern hover:border-fern"

--- a/app/ui/nav.tsx
+++ b/app/ui/nav.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import clsx from 'clsx';
 
@@ -17,18 +16,20 @@ export default function Nav() {
 		<>
 			{links.map((link) => {
 				return (
-					<Link 
-						key={link.name}
-						href={link.href}
-						className={clsx(
-							'block mt-4 lg:inline-block lg:mt-0 text-black mr-4',
-							{
-								'underline': pathname === link.href,
-							}
-						)}
-					>
-					{link.name}
-					</Link>
+					<>
+						<a 
+							key={link.name}
+							href={link.href}
+							className={clsx(
+								'block mt-4 lg:inline-block lg:mt-0 text-black mr-4',
+								{
+									'underline': pathname === link.href,
+								}
+							)}
+						>
+						{link.name}
+						</a>
+					</>
 				);
 			})}
 		</>

--- a/app/ui/subscribeform.tsx
+++ b/app/ui/subscribeform.tsx
@@ -1,0 +1,11 @@
+export default function Subscribeform() {
+	return (
+		<div className="bg-paper w-10/12 md:w-1/2 p-4 mx-auto rounded">
+          <div className="bg-goldenrod p-2 rounded">
+            <h2 className="my-2 text-center text-2xl"><strong>We're still growing!</strong></h2>
+          </div>
+			<p>Subscribe to our mailing list below and we'll email you once our borb crafting kits and handmade pieces, <strong>daydreams made in felt</strong>, take flight.</p>
+            <div className="ml-embedded" data-form="5XFz0D"></div>
+		</div>
+	);
+}

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "clsx": "^2.1.1",
+    "next": "14.2.4",
     "react": "^18",
     "react-dom": "^18",
-    "next": "14.2.4",
-    "clsx": "^2.1.1"
+    "react-helmet": "^6.1.0"
   },
   "devDependencies": {
-    "typescript": "^5",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "eslint": "^8",
+    "eslint-config-next": "14.2.4",
     "postcss": "^8",
     "tailwindcss": "^3.4.1",
-    "eslint": "^8",
-    "eslint-config-next": "14.2.4"
+    "typescript": "^5"
   }
 }


### PR DESCRIPTION
- Can finally use embedded Mailerlite form. Reference: https://github.com/vercel/next.js/discussions/47166
- Weird thing: Had to change Nav links to `<a>` tags not `Link` component. Reload on navigation is actually desireable otherwise the Mailerlite form wasn't showing up while navigating from page to page.
- Left link to subscribe.io page in header but embedded subscription form is on every page now
- Actioned on feedback that image on bg image on homepage was too noisy