### PR TITLE
Third attempt to override discount box

### DIFF
--- a/public/snipcart-templates.html
+++ b/public/snipcart-templates.html
@@ -5,7 +5,9 @@
     <body>
         <div id="snipcart-templates">
             <!-- Insert template overrides here -->
-            <discount-box>Enter any discount codes here</discount-box>
+            <div>
+                <discount-box>Enter any discount codes here</discount-box>
+            </div>
         </div>
     </body>
 </html>


### PR DESCRIPTION
Followed the question here: https://support.snipcart.com/t/overrides-to-components-are-not-applied/44

You'd think they would just put this in their docs